### PR TITLE
Email scalar introduction and time scalar refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ export default makeExecutableSchema({
     resolvers: merge({}, CustomScalars),
     typeDefs: gql`
     
-        scalar Time 
         scalar Date
+        scalar Email
+        scalar Time 
 
     `
 });
@@ -29,3 +30,7 @@ Accepts strings formatted as HH:MM like the standard HTML5 input element. This s
 ## Date 
 
 Accepts strings that follow ISO Date formatting standards. This scalar will output YYYY-MM-DD regardless the input formatting. It strips timestamps and converts the date object to a simple string.
+
+## Email
+
+Accepts all valid email formats. This includes those with multiple top-level domains. Currently, this scalar does not support domain-specific email address validation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gql-scalars",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gql-scalars",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Custom GraphQL scalar types",
   "main": "dist/index.js",
   "scripts": {

--- a/src/date.js
+++ b/src/date.js
@@ -2,6 +2,7 @@ import { GraphQLScalarType } from 'graphql';
 import { Kind } from 'graphql/language';
 
 export default new GraphQLScalarType({
+
     name: 'Date',
     description: 'ISO standard YYYY-MM-DD string',
 
@@ -9,7 +10,7 @@ export default new GraphQLScalarType({
     parseValue: value => formatDateString(value),
 
     parseLiteral: ast =>
-        ast.kind === Kind.INT ?
+        ast.kind === Kind.STRING ?
             formatDateString(ast.value) :
             null
 
@@ -17,6 +18,7 @@ export default new GraphQLScalarType({
 
 export const formatDateString = str => {
     let date = new Date(str);
+
     if (!(date instanceof Date) || isNaN(date)) {
         throw new TypeError('Invalid date input value');
     }

--- a/src/email.js
+++ b/src/email.js
@@ -1,0 +1,26 @@
+import { GraphQLScalarType } from 'graphql';
+import { Kind } from 'graphql/language';
+
+export default new GraphQLScalarType({
+
+    name: 'Email',
+    description: 'Valid email address',
+
+    serialize: value => value,
+
+    parseValue: value => validateEmail(value),
+
+    parseLiteral: ast =>
+        ast.kind === Kind.STRING ?
+            validateEmail(ast.value) :
+            null
+
+});
+
+export const validateEmail = val => {
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(val)) {
+        throw new Error('Invalid email address');
+    }
+
+    return val;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,9 @@
+import Date from './date';
+import Email from './email';
 import Time from './time';
 
 export default {
+    Date,
+    Email,
     Time
 };

--- a/src/time.js
+++ b/src/time.js
@@ -7,66 +7,25 @@ export default new GraphQLScalarType({
     name: 'Time',
     description: '24-hour clock',
 
-    serialize: value => value,
-
-    parseValue: value =>
-        new TimeBuilder_HHMM(value)
-            .build(),
+    serialize: value => formatTimeString(value),
+    parseValue: value => validateTimeString(value),
 
     parseLiteral: ({ kind, value }) =>
         kind === Kind.STRING ?
-            new TimeBuilder_HHMM(value).build() :
+            validateTimeString(value) :
             null
 
 });
 
-export class TimeBuilder_HHMM {
-
-    constructor(value) {
-
-        let char = ':';
-        let time = value.split(char);
-
-        if (!value.includes(char) || time.length > 2) {
-            throw new Error('String must contain colons to separate hours and minutes');
-        }
-
-        if (!/^.?(\d|:)*$/.test(value)) {
-            throw new Error('String must contain only colons and numbers')
-        }
-
-        this.hours = time[0];
-        this.minutes = time[1];
+export const validateTimeString = val => {
+    if (!/^(2[0-3]|[01]?[0-9]):([0-5]?[0-9])$/.test(val)) {
+        throw new Error('Invalid 24-hour time string');
     }
 
-    build() {
-        return this.getHours() + ':' + this.getMinutes();
-    }
+    return val;
+};
 
-    getHours() {
-        this.validateLength(this.hours);
-        if (parseInt(this.hours.charAt(0)) > 2 || parseInt(this.hours.charAt(1)) > 4) {
-            throw new Error('Hour value cannot be higher than 24');
-        }
-
-        return prependLeadingZero(this.hours);
-    }
-
-    getMinutes() {
-        this.validateLength(this.minutes);
-        if (parseInt(this.minutes.charAt(0)) > 5) {
-            throw new Error('Hour value cannot be higher than 59');
-        }
-
-        return prependLeadingZero(this.minutes);
-    }
-
-    validateLength(str) {
-        if (str.length > 2) {
-            throw new Error('Time values cannot exceed two characters');
-        }
-
-        return true;
-    }
-
-}
+export const formatTimeString = val => {
+    let time = val.split(':');
+    return prependLeadingZero(time[0]) + ':' + prependLeadingZero(time[1]);
+};

--- a/tests/date.unit.test.js
+++ b/tests/date.unit.test.js
@@ -1,4 +1,5 @@
-import { prependLeadingZero, formatDateString } from '../src/date';
+import { Kind } from 'graphql/language';
+import date, { prependLeadingZero, formatDateString } from '../src/date';
 
 describe('date utility functions', () => {
 
@@ -28,3 +29,18 @@ describe('date utility functions', () => {
 
 });
 
+describe('date scalar integration', () => {
+
+    it('should have name a name', () =>
+        expect(date.name)
+            .toMatch('Date'));
+
+    it('should return null if provided an integer', () =>
+        expect(date.parseLiteral({ kind: Kind.INT }))
+            .toBeNull());
+
+    it('should return date if given date string', () =>
+        expect(date.parseLiteral({ kind: Kind.STRING, value: '03-21-2019' }))
+            .toMatch('2019-03-21'));
+
+});

--- a/tests/email.unit.test.js
+++ b/tests/email.unit.test.js
@@ -1,0 +1,59 @@
+import { Kind } from 'graphql/language';
+import email, { validateEmail } from '../src/email';
+
+const validTLDWithOneDecimal = 'hello@domain.com';
+const validTLDWithTwoDecimals = 'hello@domain.com.ca.ru';
+const validIDWithNoDecimal = 'mike@domain.com';
+const validIDWithOneDecimal = 'mike.ibberson@domain.com';
+
+describe('email validation function', () => {
+
+    it('should fail without domain', () =>
+        expect(() => validateEmail('hello'))
+            .toThrowError());
+
+    it('should fail with TLD', () =>
+        expect(() => validateEmail('hello@domain'))
+            .toThrowError());
+
+    it('should accept decimals in TLDs', () =>
+        expect(validateEmail(validTLDWithOneDecimal))
+            .toMatch(validTLDWithOneDecimal));
+
+    it('should accept multiplle decimals in TLDs', () =>
+        expect(validateEmail(validTLDWithTwoDecimals))
+            .toMatch(validTLDWithTwoDecimals));
+
+    it('should accept no decimals in identifier', () =>
+        expect(validateEmail(validIDWithNoDecimal))
+            .toMatch(validIDWithNoDecimal));
+
+    it('should accept decimals in identifier', () =>
+        expect(validateEmail(validIDWithOneDecimal))
+            .toMatch(validIDWithOneDecimal));
+
+});
+
+describe('email scalar integration', () => {
+
+    it('should have name a name', () =>
+        expect(email.name)
+            .toMatch('Email'));
+
+    it('should return null if AST is not a string', () =>
+        expect(email.parseLiteral({ kind: Kind.INT }))
+            .toBeNull());
+
+    it('should return self if AST is a valid email string', () =>
+        expect(email.parseLiteral({ kind: Kind.STRING, value: validIDWithOneDecimal }))
+            .toMatch(validIDWithOneDecimal));
+
+    it('should fail if invalid email', () =>
+        expect(() => email.parseValue('notanemaiL@hello'))
+            .toThrowError());
+
+    it('should return self', () =>
+        expect(email.serialize('wow'))
+            .toMatch('wow'));
+
+});

--- a/tests/time.unit.test.js
+++ b/tests/time.unit.test.js
@@ -1,45 +1,60 @@
-import { TimeBuilder_HHMM as Time } from '../src/time';
+import { Kind } from 'graphql/language';
+import Time, { validateTimeString, formatTimeString } from '../src/time';
 
-describe('time builder class', () => {
+const validTimeString = '10:20';
+
+describe('time validation functions', () => {
 
     it('should fail without a colon', () =>
-        expect(() => new Time('1212'))
+        expect(() => validateTimeString('1212'))
             .toThrowError());
 
     it('should fail if the string contains non-alpha characters', () =>
-        expect(() => new Time('1:12am'))
+        expect(() => validateTimeString('1:12am'))
             .toThrowError());
 
-    it('should add leading 0 to hours and minutes', () =>
-        expect(new Time('1:2').build())
-            .toMatch('01:02'));
-
     it('should fail if hours are longer than three digits', () =>
-        expect(() => new Time('100:22').build())
+        expect(() => validateTimeString('100:22'))
             .toThrowError());
 
     it('should fail if there are two colons', () =>
-        expect(() => new Time('01:22:13'))
+        expect(() => validateTimeString('01:22:13'))
             .toThrowError());
 
     it('should fail if hours exceed 24', () =>
-        expect(() => new Time('25:20').getHours())
+        expect(() => validateTimeString('25:20'))
             .toThrowError());
 
     it('should fail if minutes exceed 59', () =>
-        expect(() => new Time('12:60').getMinutes())
+        expect(() => validateTimeString('12:60'))
             .toThrowError());
 
     it('should return the same value if formatted correctly', () =>
-        expect(new Time('10:20').build())
-            .toMatch('10:20'));
+        expect(validateTimeString(validTimeString))
+            .toMatch(validTimeString));
 
-    it('should fail without a value provided to the constructor', () =>
-        expect(() => new TimeBuilder_HHMM())
-            .toThrowError());
+    it('should add leading 0 to hours and minutes', () =>
+        expect(formatTimeString('1:2'))
+            .toMatch('01:02'));
 
-    it('should fail if provided with a string over two characters', () =>
-        expect(() => new Time('12:12').validateLength('123'))
-            .toThrowError());
+});
+
+describe('time scalar integration', () => {
+
+    it('should have a name', () =>
+        expect(Time.name)
+            .toMatch('Time'));
+
+    it('should fail if provided something other than a string', () =>
+        expect(Time.parseLiteral({ kind: Kind.ID }))
+            .toBeNull());
+
+    it('should return self if a string', () =>
+        expect(Time.parseLiteral({ kind: Kind.STRING, value: validTimeString }))
+            .toMatch(validTimeString));
+
+    it('should return padded time to the client', () =>
+        expect(Time.serialize('1:11'))
+            .toMatch('01:11'));
 
 });


### PR DESCRIPTION
Refactored the time builder into a single regex-driven function. While the error messages are less specific, most devs wouldn't display them to the client anyway, so that level of granular validation should be reserved for the front end.